### PR TITLE
Deleted redundant condition

### DIFF
--- a/shm/src/ship.cpp
+++ b/shm/src/ship.cpp
@@ -13,7 +13,7 @@ Ship& Ship::operator+=(size_t num) {
 }
 
 Cargo Ship::getCargo(size_t index) const {
-    if (index < 0 || index >= cargo_.size()) {
+    if (index >= cargo_.size()) {
         std::cerr << "Invalid index\n";
     }
     return cargo_[index];


### PR DESCRIPTION
Deleted redundant conditions in `getCargo` method. `index` can't be less than 0 because it's `size_t`